### PR TITLE
Add ChatGPT prompt saver extension

### DIFF
--- a/extension/content.css
+++ b/extension/content.css
@@ -1,0 +1,6 @@
+#prompt-search {
+  padding: 5px;
+}
+#prompt-results div:hover {
+  background:#eee;
+}

--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -1,0 +1,57 @@
+function createSearchBar() {
+  const inputBox = document.querySelector('form textarea');
+  if (!inputBox || document.getElementById('prompt-search')) return;
+
+  const container = document.createElement('div');
+  container.style.marginTop = '10px';
+
+  const search = document.createElement('input');
+  search.type = 'text';
+  search.placeholder = 'Search saved prompts...';
+  search.id = 'prompt-search';
+  search.style.width = '100%';
+  search.style.boxSizing = 'border-box';
+
+  const results = document.createElement('div');
+  results.id = 'prompt-results';
+  results.style.background = '#fff';
+  results.style.border = '1px solid #ccc';
+  results.style.maxHeight = '150px';
+  results.style.overflowY = 'auto';
+  results.style.display = 'none';
+  results.style.position = 'absolute';
+  results.style.zIndex = '1000';
+
+  container.appendChild(search);
+  container.appendChild(results);
+  inputBox.parentElement.appendChild(container);
+
+  search.addEventListener('input', () => {
+    const term = search.value.trim().toLowerCase();
+    if (!term) {
+      results.style.display = 'none';
+      return;
+    }
+    chrome.storage.local.get({prompts: []}, data => {
+      const matches = data.prompts.filter(p => p.title.toLowerCase().includes(term));
+      results.innerHTML = '';
+      matches.forEach(p => {
+        const item = document.createElement('div');
+        item.textContent = p.title;
+        item.style.padding = '5px';
+        item.style.cursor = 'pointer';
+        item.addEventListener('click', () => {
+          inputBox.value = p.prompt;
+          results.style.display = 'none';
+          search.value = '';
+          inputBox.focus();
+        });
+        results.appendChild(item);
+      });
+      results.style.display = matches.length ? 'block' : 'none';
+    });
+  });
+}
+
+const observer = new MutationObserver(() => createSearchBar());
+observer.observe(document.body, {childList: true, subtree: true});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Prompt Saver",
+  "description": "Save and search prompts on ChatGPT",
+  "version": "1.0",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Prompt Saver"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["contentScript.js"],
+      "css": ["content.css"],
+      "run_at": "document_end"
+    }
+  ]
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Prompt Saver</title>
+<style>
+  body { font-family: Arial, sans-serif; width: 300px; padding: 10px; }
+  input, textarea { width: 100%; margin-bottom: 5px; }
+  button { width: 100%; }
+  .prompt-list { max-height: 200px; overflow-y: auto; margin-top: 10px; }
+  .prompt-item { border-bottom: 1px solid #ddd; padding: 5px 0; }
+  .prompt-title { font-weight: bold; }
+  .prompt-desc { font-size: 0.9em; color: #555; }
+</style>
+</head>
+<body>
+  <h2>Save Prompt</h2>
+  <input type="text" id="title" placeholder="Title" />
+  <textarea id="description" placeholder="Description"></textarea>
+  <textarea id="prompt" placeholder="Prompt text"></textarea>
+  <button id="save">Save</button>
+  <div class="prompt-list" id="list"></div>
+<script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,30 @@
+function renderList(prompts) {
+  const list = document.getElementById('list');
+  list.innerHTML = '';
+  prompts.forEach((p, index) => {
+    const div = document.createElement('div');
+    div.className = 'prompt-item';
+    div.innerHTML = `<div class="prompt-title">${p.title}</div>` +
+                    `<div class="prompt-desc">${p.description}</div>`;
+    list.appendChild(div);
+  });
+}
+
+function loadPrompts() {
+  chrome.storage.local.get({prompts: []}, (data) => {
+    renderList(data.prompts);
+  });
+}
+
+document.getElementById('save').addEventListener('click', () => {
+  const title = document.getElementById('title').value.trim();
+  const description = document.getElementById('description').value.trim();
+  const prompt = document.getElementById('prompt').value.trim();
+  if (!title || !prompt) return;
+  chrome.storage.local.get({prompts: []}, (data) => {
+    data.prompts.push({title, description, prompt});
+    chrome.storage.local.set({prompts: data.prompts}, loadPrompts);
+  });
+});
+
+loadPrompts();

--- a/readme
+++ b/readme
@@ -1,1 +1,13 @@
+# ChatGPT Prompt Saver Chrome Extension
 
+This extension allows you to save prompts with a title and description and quickly insert them on the ChatGPT website. A search box appears under ChatGPT's input field for finding your saved prompts by title.
+
+## Installation
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode** in the top-right corner.
+3. Click **Load unpacked** and select the `extension` folder in this repository.
+
+## Usage
+1. Click the extension icon and fill in the title, description, and prompt text, then click **Save**.
+2. Visit [chat.openai.com](https://chat.openai.com) and you'll see a search field under the message input area.
+3. Start typing a title to find your saved prompts. Selecting one will insert the prompt text into the input box.


### PR DESCRIPTION
## Summary
- create a Chrome extension to save and reuse prompts on ChatGPT
- inject a search bar under ChatGPT's input field for selecting saved prompts
- provide a popup UI for saving prompts
- document installation and usage steps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885d223a4e8833283af3e3acee12caa