### PR TITLE
Add popup UI and background script for prompt management

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,8 @@
+// Initialize storage when the extension is installed.
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.get({prompts: []}, data => {
+    if (!Array.isArray(data.prompts)) {
+      chrome.storage.local.set({prompts: []});
+    }
+  });
+});

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,12 @@
   "version": "1.0",
   "permissions": ["storage"],
   "host_permissions": ["https://chat.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": ["https://chat.openai.com/*"],

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -1,0 +1,41 @@
+body {
+  background: #2b2b2b;
+  color: #eee;
+  font-family: sans-serif;
+  margin: 0;
+  padding: 10px;
+  width: 300px;
+  box-sizing: border-box;
+}
+button {
+  margin-top: 10px;
+  width: 100%;
+  padding: 6px;
+  box-sizing: border-box;
+}
+#prompt-list .entry {
+  border-bottom: 1px solid #444;
+  padding: 6px 0;
+}
+.entry-title {
+  font-weight: bold;
+}
+.entry-actions button {
+  width: auto;
+  margin-left: 4px;
+}
+dialog {
+  background: #3b3b3b;
+  color: #fff;
+  border: none;
+  padding: 10px;
+}
+.dialog-buttons {
+  margin-top: 10px;
+  text-align: right;
+}
+input, textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 4px;
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Prompt Manager</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div id="prompt-list"></div>
+  <button id="add">Add Prompt</button>
+
+  <dialog id="dialog">
+    <form id="prompt-form" method="dialog">
+      <label>Title
+        <input type="text" id="title" required />
+      </label>
+      <label>Description
+        <input type="text" id="description" />
+      </label>
+      <label>Prompt
+        <textarea id="text" rows="4" required></textarea>
+      </label>
+      <div class="dialog-buttons">
+        <button id="save" type="submit">Save</button>
+        <button id="cancel" type="button">Cancel</button>
+      </div>
+    </form>
+  </dialog>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,69 @@
+let editIndex = null;
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('add').addEventListener('click', () => openDialog());
+  document.getElementById('prompt-form').addEventListener('submit', savePrompt);
+  document.getElementById('cancel').addEventListener('click', closeDialog);
+  loadPrompts();
+});
+
+function loadPrompts() {
+  chrome.storage.local.get({prompts: []}, data => {
+    const list = document.getElementById('prompt-list');
+    list.innerHTML = '';
+    data.prompts.forEach((p, index) => {
+      const div = document.createElement('div');
+      div.className = 'entry';
+      div.innerHTML = `<div class="entry-title">${p.title}</div>` +
+        `<div class="entry-desc">${p.description}</div>`;
+      const actions = document.createElement('div');
+      actions.className = 'entry-actions';
+      const edit = document.createElement('button');
+      edit.textContent = 'Edit';
+      edit.addEventListener('click', () => openDialog(p, index));
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.addEventListener('click', () => {
+        data.prompts.splice(index, 1);
+        chrome.storage.local.set({prompts: data.prompts}, loadPrompts);
+      });
+      actions.appendChild(edit);
+      actions.appendChild(del);
+      div.appendChild(actions);
+      list.appendChild(div);
+    });
+  });
+}
+
+function openDialog(prompt = {}, index = null) {
+  editIndex = index;
+  document.getElementById('title').value = prompt.title || '';
+  document.getElementById('description').value = prompt.description || '';
+  document.getElementById('text').value = prompt.text || '';
+  document.getElementById('dialog').showModal();
+}
+
+function closeDialog() {
+  document.getElementById('dialog').close();
+}
+
+function savePrompt(e) {
+  e.preventDefault();
+  const title = document.getElementById('title').value.trim();
+  const description = document.getElementById('description').value.trim();
+  const text = document.getElementById('text').value;
+  if (!title || !text) return;
+
+  chrome.storage.local.get({prompts: []}, data => {
+    if (editIndex === null) {
+      data.prompts.push({title, description, text});
+    } else {
+      data.prompts[editIndex] = {title, description, text};
+    }
+    chrome.storage.local.set({prompts: data.prompts}, () => {
+      editIndex = null;
+      closeDialog();
+      loadPrompts();
+    });
+  });
+}

--- a/extension/style.css
+++ b/extension/style.css
@@ -1,5 +1,6 @@
 #prompt-search-container {
   margin-top: 4px;
+  position: relative;
 }
 #prompt-search {
   width: 100%;
@@ -7,12 +8,14 @@
   box-sizing: border-box;
 }
 #prompt-results {
-  background: white;
+  background: #fff;
+  color: #000;
   border: 1px solid #ccc;
   max-height: 200px;
   overflow-y: auto;
   z-index: 1000;
   position: absolute;
+  width: 100%;
 }
 .prompt-item {
   padding: 4px;
@@ -20,4 +23,19 @@
 }
 .prompt-item:hover {
   background-color: #eee;
+}
+@media (prefers-color-scheme: dark) {
+  #prompt-search {
+    background: #555;
+    color: #fff;
+    border: 1px solid #444;
+  }
+  #prompt-results {
+    background: #333;
+    color: #eee;
+    border-color: #555;
+  }
+  .prompt-item:hover {
+    background-color: #444;
+  }
 }


### PR DESCRIPTION
## Summary
- add popup UI to manage saved prompts
- support editing, deleting and adding prompts
- implement dark themed popup styling
- store prompts via background service worker
- update manifest to register popup and background
- enhance search bar styles with dark mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886bfb79bd083329524b322eec063c6