### PR TITLE
Add prompt saving dialog

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -8,4 +8,4 @@ for them directly on the ChatGPT page.
 2. Enable **Developer mode**.
 3. Click **Load unpacked** and select this `extension` folder.
 4. Open ChatGPT and you will see a search bar below the message box.
-5. Use the extension options page to add or remove saved prompts.
+5. Use the **Add Prompt** button in the search bar or the options page to save or remove prompts.

--- a/extension/content.js
+++ b/extension/content.js
@@ -16,12 +16,56 @@ function createSearchUI(textarea) {
   const input = document.createElement('input');
   input.id = 'prompt-search';
   input.placeholder = 'Search saved prompts...';
+  const addBtn = document.createElement('button');
+  addBtn.id = 'add-prompt';
+  addBtn.textContent = 'Add Prompt';
   const results = document.createElement('div');
   results.id = 'prompt-results';
   results.style.display = 'none';
   container.appendChild(input);
+  container.appendChild(addBtn);
   container.appendChild(results);
   textarea.parentElement.appendChild(container);
+
+  const dialog = document.createElement('dialog');
+  dialog.id = 'prompt-dialog';
+  dialog.innerHTML = `
+    <form method="dialog" id="prompt-dialog-form">
+      <label>Title<br><input type="text" id="prompt-title" required></label>
+      <label>Description<br><input type="text" id="prompt-desc"></label>
+      <label>Prompt<br><textarea id="prompt-text" rows="4" required></textarea></label>
+      <div class="dialog-buttons">
+        <button id="save-prompt" type="submit">Save</button>
+        <button id="cancel-prompt" type="button">Cancel</button>
+      </div>
+    </form>`;
+  container.appendChild(dialog);
+
+  addBtn.addEventListener('click', () => {
+    dialog.querySelector('#prompt-title').value = '';
+    dialog.querySelector('#prompt-desc').value = '';
+    dialog.querySelector('#prompt-text').value = textarea.value;
+    dialog.showModal();
+  });
+
+  dialog.querySelector('#cancel-prompt').addEventListener('click', () => {
+    dialog.close();
+  });
+
+  dialog.querySelector('#prompt-dialog-form').addEventListener('submit', e => {
+    e.preventDefault();
+    const title = dialog.querySelector('#prompt-title').value.trim();
+    const description = dialog.querySelector('#prompt-desc').value.trim();
+    const text = dialog.querySelector('#prompt-text').value;
+    if (!title || !text) return;
+    chrome.storage.local.get({prompts: []}, data => {
+      data.prompts.push({title, description, text});
+      chrome.storage.local.set({prompts: data.prompts}, () => {
+        dialog.close();
+        input.dispatchEvent(new Event('input'));
+      });
+    });
+  });
 
   input.addEventListener('input', () => {
     const query = input.value.toLowerCase();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "ChatGPT Prompt Saver",
   "description": "Save and search prompts in ChatGPT.",
-  "version": "1.0",
+  "version": "1.1",
   "permissions": ["storage"],
   "host_permissions": ["https://chat.openai.com/*"],
   "action": {

--- a/extension/style.css
+++ b/extension/style.css
@@ -24,6 +24,29 @@
 .prompt-item:hover {
   background-color: #eee;
 }
+#add-prompt {
+  margin-top: 4px;
+  padding: 6px;
+  width: 100%;
+  box-sizing: border-box;
+}
+#prompt-dialog {
+  padding: 10px;
+}
+#prompt-dialog form label {
+  display: block;
+  margin-top: 8px;
+}
+#prompt-dialog input,
+#prompt-dialog textarea {
+  width: 100%;
+  box-sizing: border-box;
+  margin-top: 4px;
+}
+#prompt-dialog .dialog-buttons {
+  margin-top: 10px;
+  text-align: right;
+}
 @media (prefers-color-scheme: dark) {
   #prompt-search {
     background: #555;
@@ -31,6 +54,11 @@
     border: 1px solid #444;
   }
   #prompt-results {
+    background: #333;
+    color: #eee;
+    border-color: #555;
+  }
+  #prompt-dialog {
     background: #333;
     color: #eee;
     border-color: #555;


### PR DESCRIPTION
## Summary
- add dialog to save prompts directly from ChatGPT page
- style new button and dialog
- bump extension version to 1.1
- update README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886c258c7808332a083cbfbd530d0f6