### PR TITLE
Add ChatGPT Bookmarker extension

### DIFF
--- a/chatgpt_bookmarker/content.js
+++ b/chatgpt_bookmarker/content.js
@@ -1,0 +1,61 @@
+// content.js - injected into ChatGPT pages
+// Adds bookmark icons to each message and handles storing bookmarks
+
+// CSS class for bookmark icon
+const BOOKMARK_CLASS = 'cgpt-bookmark-icon';
+
+// Observe DOM changes to catch new messages
+const observer = new MutationObserver(() => {
+  addIcons();
+});
+
+observer.observe(document.body, { childList: true, subtree: true });
+
+// Initial call
+addIcons();
+
+// Add bookmark icons next to thumbs icons
+function addIcons() {
+  // Messages have attribute data-message-author-role
+  const messages = document.querySelectorAll('div[data-message-author-role]');
+  messages.forEach(msg => {
+    // Avoid adding twice
+    if (msg.querySelector('.' + BOOKMARK_CLASS)) return;
+
+    const actionsContainer = msg.querySelector('div.flex.items-center');
+    // Fallback to message element if action bar not found
+    const container = actionsContainer || msg;
+
+    const icon = document.createElement('span');
+    icon.textContent = '🔖';
+    icon.title = 'Bookmark this message';
+    icon.className = BOOKMARK_CLASS;
+    icon.style.cursor = 'pointer';
+    icon.style.marginLeft = '4px';
+
+    icon.addEventListener('click', e => {
+      e.stopPropagation();
+      bookmarkMessage(msg.innerText.trim());
+    });
+
+    container.appendChild(icon);
+  });
+}
+
+// Store message text in chrome.storage.local
+function bookmarkMessage(text) {
+  chrome.storage.local.get({ bookmarks: [] }, data => {
+    const bookmarks = data.bookmarks;
+    bookmarks.push({ text, url: location.href, time: Date.now() });
+    chrome.storage.local.set({ bookmarks });
+  });
+}
+
+// Listen for requests from popup.js to get all messages
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'get_messages') {
+    const messages = Array.from(document.querySelectorAll('div[data-message-author-role]'))
+      .map(el => el.innerText.trim());
+    sendResponse({ messages });
+  }
+});

--- a/chatgpt_bookmarker/manifest.json
+++ b/chatgpt_bookmarker/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Bookmarker",
+  "version": "1.0",
+  "description": "Bookmark ChatGPT messages and summarize chats.",
+  "permissions": ["storage"],
+  "host_permissions": ["https://chat.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "ChatGPT Bookmarker"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chatgpt_bookmarker/popup.html
+++ b/chatgpt_bookmarker/popup.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ChatGPT Bookmarker</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Bookmarks</h1>
+  <ul id="bookmarkList"></ul>
+  <button id="summarizeBtn">Summarize This Chat</button>
+  <div id="summary"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chatgpt_bookmarker/popup.js
+++ b/chatgpt_bookmarker/popup.js
@@ -1,0 +1,46 @@
+// popup.js - handles displaying bookmarks and summarizing chat
+
+// Load bookmarks from storage and display them
+function loadBookmarks() {
+  chrome.storage.local.get({ bookmarks: [] }, data => {
+    const list = document.getElementById('bookmarkList');
+    list.innerHTML = '';
+    data.bookmarks.forEach((b, idx) => {
+      const li = document.createElement('li');
+      li.textContent = b.text.slice(0, 80);
+      list.appendChild(li);
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadBookmarks();
+  document.getElementById('summarizeBtn').addEventListener('click', summarize);
+});
+
+// Request messages from the active tab and generate a naive summary
+function summarize() {
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    const tab = tabs[0];
+    chrome.tabs.sendMessage(tab.id, { action: 'get_messages' }, response => {
+      if (!response) return;
+      const msgs = response.messages;
+      const allText = msgs.join(' ');
+      const words = allText.split(/\s+/);
+      const summary = words.slice(0, 50).join(' ') + (words.length > 50 ? '...' : '');
+      const actions = msgs.filter(t => /\b(todo|action|remember)\b/i.test(t));
+      const div = document.getElementById('summary');
+      div.innerHTML = '<h2>Summary</h2><p>' + summary + '</p>';
+      if (actions.length) {
+        const ul = document.createElement('ul');
+        actions.forEach(a => {
+          const li = document.createElement('li');
+          li.textContent = a.slice(0, 80);
+          ul.appendChild(li);
+        });
+        div.appendChild(document.createElement('h3')).textContent = 'Action Items';
+        div.appendChild(ul);
+      }
+    });
+  });
+}

--- a/chatgpt_bookmarker/styles.css
+++ b/chatgpt_bookmarker/styles.css
@@ -1,0 +1,23 @@
+/* styles.css - popup and icon styles */
+
+body {
+  font-family: Arial, sans-serif;
+  min-width: 250px;
+  padding: 10px;
+}
+
+#bookmarkList {
+  list-style-type: none;
+  padding: 0;
+  max-height: 150px;
+  overflow-y: auto;
+}
+
+.cgpt-bookmark-icon {
+  cursor: pointer;
+  margin-left: 4px;
+}
+
+#summary {
+  margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- add new ChatGPT Bookmarker extension with Manifest v3
- inject bookmark icons and store messages using content script
- add popup to view bookmarks and summarize visible chat

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c0052cfc48332a8752bccb2e00f43