### PR TITLE
Add ChatGPT Bookmarker extension

### DIFF
--- a/bookmark_extension/content.js
+++ b/bookmark_extension/content.js
@@ -1,0 +1,54 @@
+// Content script for ChatGPT Bookmarker
+// This script injects bookmark buttons into each ChatGPT message
+// and listens for messages from the popup to provide chat contents.
+
+// Utility to add bookmark buttons to all messages
+function addBookmarks() {
+  // ChatGPT messages are contained in elements with data-testid="conversation-turn".
+  // We iterate through each and inject a button if it doesn't already exist.
+  const turns = document.querySelectorAll('[data-testid="conversation-turn"]');
+  turns.forEach(turn => {
+    // Avoid inserting multiple buttons
+    if (turn.querySelector('.chatgpt-bookmark-btn')) return;
+
+    // Locate the footer that contains the thumbs buttons
+    const footer = turn.querySelector('div.flex.gap-2') ||
+                   turn.querySelector('div.flex.justify-between');
+    if (!footer) return;
+
+    // Create bookmark button
+    const btn = document.createElement('button');
+    btn.textContent = '🔖'; // simple bookmark icon
+    btn.title = 'Bookmark this message';
+    btn.className = 'chatgpt-bookmark-btn';
+
+    // Save the text when clicked
+    btn.addEventListener('click', () => {
+      const textEl = turn.querySelector('.markdown');
+      const text = textEl ? textEl.innerText : turn.innerText;
+      chrome.storage.local.get({bookmarks: []}, data => {
+        data.bookmarks.push({text, time: Date.now()});
+        chrome.storage.local.set({bookmarks: data.bookmarks});
+      });
+    });
+
+    footer.appendChild(btn);
+  });
+}
+
+// Observe DOM changes to catch new messages
+const observer = new MutationObserver(addBookmarks);
+observer.observe(document.body, {childList: true, subtree: true});
+
+// Initial run after page load
+addBookmarks();
+
+// Listen for requests from popup to gather all messages
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'get_messages') {
+    const msgs = Array.from(document.querySelectorAll('[data-testid="conversation-turn"] .markdown'))
+      .map(el => el.innerText.trim());
+    sendResponse({messages: msgs});
+    return true; // keep the channel open
+  }
+});

--- a/bookmark_extension/manifest.json
+++ b/bookmark_extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Bookmarker",
+  "description": "Bookmark ChatGPT messages and summarize chats.",
+  "version": "1.0",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "host_permissions": ["https://chat.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "ChatGPT Bookmarker"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content.js"],
+      "css": ["styles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/bookmark_extension/popup.html
+++ b/bookmark_extension/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>ChatGPT Bookmarker</title>
+  <!-- Popup styling -->
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Bookmarks</h1>
+  <!-- Container for stored messages -->
+  <div id="bookmarks"></div>
+
+  <!-- Button to summarize the current chat -->
+  <button id="summarize">Summarize This Chat</button>
+
+  <h2>Summary</h2>
+  <p id="summary"></p>
+
+  <h3>Action Items</h3>
+  <ul id="actions"></ul>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/bookmark_extension/popup.js
+++ b/bookmark_extension/popup.js
@@ -1,0 +1,60 @@
+// Popup script for ChatGPT Bookmarker
+// Displays saved bookmarks and provides a summarize button.
+
+document.addEventListener('DOMContentLoaded', () => {
+  renderBookmarks();
+  document.getElementById('summarize').addEventListener('click', summarizeChat);
+});
+
+// Load bookmarks from storage and show them in the popup
+function renderBookmarks() {
+  chrome.storage.local.get({bookmarks: []}, data => {
+    const container = document.getElementById('bookmarks');
+    container.innerHTML = '';
+    data.bookmarks.forEach(bm => {
+      const div = document.createElement('div');
+      div.className = 'bookmark-item';
+      div.textContent = bm.text;
+      container.appendChild(div);
+    });
+  });
+}
+
+// Ask the content script for visible messages and produce a summary
+function summarizeChat() {
+  chrome.tabs.query({active: true, currentWindow: true}, tabs => {
+    if (!tabs.length) return;
+    chrome.tabs.sendMessage(tabs[0].id, {action: 'get_messages'}, res => {
+      if (!res) return;
+      const summary = createSummary(res.messages);
+      const actions = extractActions(res.messages);
+      document.getElementById('summary').textContent = summary;
+      const list = document.getElementById('actions');
+      list.innerHTML = '';
+      actions.forEach(a => {
+        const li = document.createElement('li');
+        li.textContent = a;
+        list.appendChild(li);
+      });
+    });
+  });
+}
+
+// Very naive summarization: return the first 100 words of the chat
+function createSummary(msgs) {
+  const words = msgs.join(' ').split(/\s+/);
+  return words.slice(0, 100).join(' ') + (words.length > 100 ? '...' : '');
+}
+
+// Extract lines that look like action items
+function extractActions(msgs) {
+  const actions = [];
+  msgs.forEach(m => {
+    m.split('\n').forEach(line => {
+      if (/^(\-|\*|\d+\.)\s+/.test(line) || line.toLowerCase().includes('todo') || line.toLowerCase().startsWith('action')) {
+        actions.push(line.trim());
+      }
+    });
+  });
+  return actions;
+}

--- a/bookmark_extension/styles.css
+++ b/bookmark_extension/styles.css
@@ -1,0 +1,39 @@
+/* Common styles for the content script and popup */
+
+/* Bookmark button next to each message */
+.chatgpt-bookmark-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 14px;
+  margin-left: 4px;
+  opacity: 0.6;
+}
+
+.chatgpt-bookmark-btn:hover {
+  opacity: 1;
+}
+
+/* Popup layout */
+body {
+  font-family: sans-serif;
+  min-width: 250px;
+  padding: 10px;
+}
+
+#bookmarks {
+  max-height: 150px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+  border: 1px solid #ccc;
+  padding: 5px;
+}
+
+.bookmark-item {
+  padding: 4px 0;
+  border-bottom: 1px solid #eee;
+}
+
+button {
+  margin-top: 5px;
+}


### PR DESCRIPTION
## Summary
- add new Chrome extension `ChatGPT Bookmarker`
- include Manifest V3 config
- implement content script to inject bookmark icons and capture messages
- implement popup to show bookmarks and summarize active chat
- add shared styles for content and popup

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688c0052cfc48332a8752bccb2e00f43