### PR TITLE
Add chatgpt bookmarker extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Repository
 
-This repository contains a simple Chrome extension located in the `extension`
-folder. The extension adds a prompt search bar to the ChatGPT website and lets
-users store prompts with titles and descriptions.
+This repository provides two Chrome extensions located in the `extension` and `chatgpt_bookmarker` folders.
+
+- `extension`: Adds a prompt search bar to ChatGPT so you can store prompts with titles and descriptions.
+- `chatgpt_bookmarker`: Lets you bookmark ChatGPT conversations for later reference.
+
+## Installation
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and choose the folder for the extension you want to install:
+   - Select the `extension` folder for the prompt saver.
+   - Select the `chatgpt_bookmarker` folder for the bookmarker extension.
+
+After loading an extension, open ChatGPT to use its new features.

--- a/chatgpt_bookmarker/README.md
+++ b/chatgpt_bookmarker/README.md
@@ -1,0 +1,9 @@
+# ChatGPT Bookmarker Chrome Extension
+
+This extension lets you bookmark entire ChatGPT conversations.
+
+## Installation
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this `chatgpt_bookmarker` folder.
+4. Open ChatGPT and use the **Bookmark Chat** button to save conversations.

--- a/chatgpt_bookmarker/background.js
+++ b/chatgpt_bookmarker/background.js
@@ -1,0 +1,8 @@
+// Ensure bookmarks array exists on install.
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.get({bookmarks: []}, data => {
+    if (!Array.isArray(data.bookmarks)) {
+      chrome.storage.local.set({bookmarks: []});
+    }
+  });
+});

--- a/chatgpt_bookmarker/content.js
+++ b/chatgpt_bookmarker/content.js
@@ -1,0 +1,36 @@
+function waitForChatContainer() {
+  return new Promise(resolve => {
+    const i = setInterval(() => {
+      const container = document.querySelector('textarea')?.parentElement;
+      if (container) {
+        clearInterval(i);
+        resolve(container);
+      }
+    }, 500);
+  });
+}
+
+function collectConversation() {
+  const msgs = Array.from(document.querySelectorAll('[data-message-author-role]'));
+  return msgs.map(m => m.innerText).join('\n\n');
+}
+
+function addBookmarkButton(container) {
+  const btn = document.createElement('button');
+  btn.id = 'bookmark-chat';
+  btn.textContent = 'Bookmark Chat';
+  btn.style.marginLeft = '8px';
+  container.appendChild(btn);
+
+  btn.addEventListener('click', () => {
+    const title = prompt('Bookmark title:', 'Chat at ' + new Date().toLocaleString());
+    if (!title) return;
+    const convo = collectConversation();
+    chrome.storage.local.get({bookmarks: []}, data => {
+      data.bookmarks.push({title, convo, time: Date.now()});
+      chrome.storage.local.set({bookmarks: data.bookmarks});
+    });
+  });
+}
+
+waitForChatContainer().then(addBookmarkButton);

--- a/chatgpt_bookmarker/manifest.json
+++ b/chatgpt_bookmarker/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Bookmarker",
+  "description": "Bookmark ChatGPT conversations for later.",
+  "version": "1.0",
+  "permissions": ["storage"],
+  "host_permissions": ["https://chat.openai.com/*"],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/chatgpt_bookmarker/popup.css
+++ b/chatgpt_bookmarker/popup.css
@@ -1,0 +1,18 @@
+body {
+  font-family: Arial, sans-serif;
+  min-width: 300px;
+}
+.item {
+  border-bottom: 1px solid #ccc;
+  padding: 6px 0;
+}
+.title {
+  font-weight: bold;
+}
+.convo {
+  width: 100%;
+  height: 80px;
+}
+.actions {
+  margin-top: 4px;
+}

--- a/chatgpt_bookmarker/popup.html
+++ b/chatgpt_bookmarker/popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Bookmarks</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div id="list"></div>
+  <template id="item-template">
+    <div class="item">
+      <div class="title"></div>
+      <textarea readonly class="convo"></textarea>
+      <div class="actions">
+        <button class="copy">Copy</button>
+        <button class="delete">Delete</button>
+      </div>
+    </div>
+  </template>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chatgpt_bookmarker/popup.js
+++ b/chatgpt_bookmarker/popup.js
@@ -1,0 +1,22 @@
+function render() {
+  chrome.storage.local.get({bookmarks: []}, data => {
+    const list = document.getElementById('list');
+    list.innerHTML = '';
+    const tmpl = document.getElementById('item-template');
+    data.bookmarks.forEach((b, idx) => {
+      const item = tmpl.content.firstElementChild.cloneNode(true);
+      item.querySelector('.title').textContent = b.title;
+      item.querySelector('.convo').value = b.convo;
+      item.querySelector('.copy').addEventListener('click', () => {
+        navigator.clipboard.writeText(b.convo);
+      });
+      item.querySelector('.delete').addEventListener('click', () => {
+        data.bookmarks.splice(idx, 1);
+        chrome.storage.local.set({bookmarks: data.bookmarks}, render);
+      });
+      list.appendChild(item);
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', render);


### PR DESCRIPTION
## Summary
- document both `extension` and `chatgpt_bookmarker` folders
- clarify that each folder contains its own Chrome extension

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688c02957cbc8332a01e83014c373acc